### PR TITLE
fix partial writes in sha256_hash

### DIFF
--- a/sha256.c
+++ b/sha256.c
@@ -148,11 +148,11 @@ void sha256_hash(sha256_context *ctx, uint8_t *dat, uint32_t sz)
 
     for (j = 0, l = 64-i; sz >= l; j += l, sz -= l, l = 64, i = 0)
     {
-        MEMCP(&ctx->buf[i], &dat[j], l);
+        MEMCP((char *)ctx->buf + i, &dat[j], l);
         BSWP(ctx->buf, 16 );
         _hash(ctx);
     }
-    MEMCP(&ctx->buf[i], &dat[j], sz);
+    MEMCP((char *)ctx->buf + i, &dat[j], sz);
 
 } /* _hash */
 


### PR DESCRIPTION
- In sha256_hash calculate the buffer address to write to using char *
  offset instead of uint32_t *.

Prior to this change if an empty buffer was partially filled in a call
to sha256_hash then a subsequent call would calculate the append point
incorrectly, causing an out-of-bounds write.