### PR TITLE
Set CC where either GCC or clang is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = clang
+CC = $(if $(shell which clang),clang,gcc)
 CFLAGS= -O3 -pedantic -Wall -Wextra -std=c99
 CBMC = cbmc
 TARGET = sha256


### PR DESCRIPTION
Hello,
SHA256 Makefile explicitly sets `CC` to `clang` but GNU systems usually ships with GCC by default (in most cases). So it'd be nicer to just use the default one by checking whether one of them is available/installed.